### PR TITLE
[IMP] Use different images for different screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/vendor

--- a/hooks/slider-selection.php
+++ b/hooks/slider-selection.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Display default slider
  *
@@ -8,40 +9,40 @@
  * @return void
  *
  */
-if ( !function_exists('event_star_default_slider') ) :
+if (!function_exists('event_star_default_slider')) :
     function event_star_default_slider()
     {
         global $event_star_customizer_all_values;
 
         $bg_image_style = '';
 
-        if ( get_header_image() ) :
-            $bg_image_style .= 'background-image:url(' . esc_url( get_header_image() ) . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
-        else:
-            $bg_image_style .= 'background-image:url(' . esc_url( get_template_directory_uri() . "/assets/img/default-image.jpg" ) . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
+        if (get_header_image()) :
+            $bg_image_style .= 'background-image:url(' . esc_url(get_header_image()) . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
+        else :
+            $bg_image_style .= 'background-image:url(' . esc_url(get_template_directory_uri() . "/assets/img/default-image.jpg") . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
         endif; // End header image check.
 
         $text_align = 'text-left';
         $animation1 = 'init-animate';
         $animation2 = 'init-animate';
-        ?>
+?>
         <div class="image-slider-wrapper home-fullscreen ">
             <div class="featured-slider">
                 <div class="item" style="<?php echo $bg_image_style; ?>">
-                    <div class="slider-content <?php echo $text_align;?>">
+                    <div class="slider-content <?php echo $text_align; ?>">
                         <div class="container">
-                            <div class="banner-title <?php echo $animation1;?>">
-                                <?php esc_html_e('Event Star', 'event-star' );?>
+                            <div class="banner-title <?php echo $animation1; ?>">
+                                <?php esc_html_e('Event Star', 'event-star'); ?>
                             </div>
-                            <div class="image-slider-caption <?php echo $animation2;?>">
-                                <?php esc_html_e('The modern Event WordPress Theme', 'event-star' );?>
+                            <div class="image-slider-caption <?php echo $animation2; ?>">
+                                <?php esc_html_e('The modern Event WordPress Theme', 'event-star'); ?>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    <?php
+        <?php
     }
 endif;
 
@@ -54,13 +55,13 @@ endif;
  * @return void
  */
 
-if ( ! function_exists( 'event_star_feature_slider' ) ) :
+if (!function_exists('event_star_feature_slider')) :
 
-    function event_star_feature_slider( )
+    function event_star_feature_slider()
     {
         global $event_star_customizer_all_values;
 
-        $event_star_slides_data = json_decode( $event_star_customizer_all_values['event-star-slides-data'] );
+        $event_star_slides_data = json_decode($event_star_customizer_all_values['event-star-slides-data']);
         $event_star_feature_slider_text_align = $event_star_customizer_all_values['event-star-feature-slider-text-align'];
         $event_star_feature_slider_enable_animation = $event_star_customizer_all_values['event-star-feature-slider-enable-animation'];
         $event_star_feature_slider_image_only = $event_star_customizer_all_values['event-star-feature-slider-display-title'];
@@ -70,9 +71,9 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
         $post_in = array();
         $slides_other_data = array();
 
-        if( is_array( $event_star_slides_data ) ) {
-            foreach ( $event_star_slides_data as $slides_data ) {
-                if( isset( $slides_data->selectpage ) && !empty( $slides_data->selectpage ) ) {
+        if (is_array($event_star_slides_data)) {
+            foreach ($event_star_slides_data as $slides_data) {
+                if (isset($slides_data->selectpage) && !empty($slides_data->selectpage)) {
                     $post_in[] = $slides_data->selectpage;
                     $slides_other_data[$slides_data->selectpage] = array(
                         'event-date'     => $slides_data->event_date,
@@ -85,21 +86,21 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
             }
         }
 
-        if( !empty( $post_in )) :
+        if (!empty($post_in)) :
             $event_star_child_page_args = array(
                 'post__in'          => $post_in,
                 'orderby'           => 'post__in',
-                'posts_per_page'    => count( $post_in ),
+                'posts_per_page'    => count($post_in),
                 'post_type'         => 'page',
                 'no_found_rows'     => true,
                 'post_status'       => 'publish'
             );
-            $slider_query = new WP_Query( $event_star_child_page_args );
+            $slider_query = new WP_Query($event_star_child_page_args);
 
             /*The Loop*/
-            if ( $slider_query->have_posts() ):
-            ?>
-                <div class="image-slider-wrapper home-fullscreen <?php echo esc_attr( $event_star_fs_image_display_options ); ?>">
+            if ($slider_query->have_posts()) :
+        ?>
+                <div class="image-slider-wrapper home-fullscreen <?php echo esc_attr($event_star_fs_image_display_options); ?>">
                     <div class="featured-slider">
                         <?php
                         $slider_index = 1;
@@ -111,11 +112,11 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
 
                         $bg_image_style = '';
 
-                        if( 'alternate' != $event_star_feature_slider_text_align ) {
+                        if ('alternate' != $event_star_feature_slider_text_align) {
                             $text_align = $event_star_feature_slider_text_align;
                         }
 
-                        if( 1 == $event_star_feature_slider_enable_animation ) {
+                        if (1 == $event_star_feature_slider_enable_animation) {
                             $animation1 = 'init-animate fadeInDown';
                             $animation2 = 'init-animate fadeInDown';
                             $animation3 = 'init-animate fadeInDown';
@@ -123,103 +124,110 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
                             $animation5 = 'init-animate fadeInDown';
                         }
 
-                        while( $slider_query->have_posts() ):$slider_query->the_post();
+                        while ($slider_query->have_posts()) : $slider_query->the_post();
 
-                            if( 'alternate' == $event_star_feature_slider_text_align ) {
-                                if( 1 == $slider_index ) {
+                            if ('alternate' == $event_star_feature_slider_text_align) {
+                                if (1 == $slider_index) {
                                     $text_align = 'text-left';
-                                } elseif ( 2 == $slider_index ) {
+                                } elseif (2 == $slider_index) {
                                     $text_align = 'text-center';
                                 } else {
                                     $text_align = 'text-right';
                                 }
                             }
 
-                            if ( has_post_thumbnail() ) {
-                                $image_url = wp_get_attachment_image_src( get_post_thumbnail_id(), 'full' );
+                            if (wp_is_mobile()) {
+                                $featuredImage = get_field('mobile_featured_image');
                             } else {
-                                $image_url[0] = get_template_directory_uri() . '/assets/img/default-image.jpg';
+                                $featuredImage = get_field('desktop_featured_image');
                             }
 
-                            if( 'full-screen-bg' == $event_star_fs_image_display_options ){
-                                $bg_image_style = 'background-image:url(' . esc_url( $image_url[0] ) . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
+                            if ($featuredImage) {
+                                $featuredImageUrl = $featuredImage['url'];
+                            } else {
+                                $featuredImage = get_template_directory_uri() . '/assets/img/default-image.jpg';
+                                $featuredImageUrl = $featuredImage[0];
+                            }
+
+                            if ('full-screen-bg' == $event_star_fs_image_display_options) {
+                                $bg_image_style = 'background-image:url(' . esc_url($featuredImageUrl) . ');background-repeat:no-repeat;background-size:cover;background-position:center;';
                             }
 
                             $slides_single_data = $slides_other_data[get_the_ID()];
-                            ?>
+                        ?>
 
                             <div class="item" style="<?php echo $bg_image_style; ?>">
                                 <?php
-                                if( 'responsive-img' == $event_star_fs_image_display_options ){
-                                    echo '<img src="' . esc_url( $image_url[0] ) . '"/>';
+                                if ('responsive-img' == $event_star_fs_image_display_options) {
+                                    echo '<img src="' . esc_url($featuredImageUrl) . '"/>';
                                 }
                                 ?>
 
-                                <div class="slider-content <?php echo esc_attr( $text_align );?>">
+                                <div class="slider-content <?php echo esc_attr($text_align); ?>">
                                     <div class="container">
                                         <?php
-                                        if( 1 == $event_star_feature_slider_image_only ) {
+                                        if (1 == $event_star_feature_slider_image_only) {
                                         ?>
-                                            <div class="banner-title <?php echo esc_attr( $animation1 );?>">
-                                              <h1 id="banner-title"><?php the_title()?></h1>
+                                            <div class="banner-title <?php echo esc_attr($animation1); ?>">
+                                                <h1 id="banner-title"><?php the_title() ?></h1>
                                             </div>
                                         <?php
                                         }
 
-                                        if( 1 == $event_star_feature_slider_image_excerpt ){
+                                        if (1 == $event_star_feature_slider_image_excerpt) {
                                         ?>
-                                            <div class="image-slider-caption <?php echo esc_attr( $animation2 );?>">
+                                            <div class="image-slider-caption <?php echo esc_attr($animation2); ?>">
                                                 <?php the_excerpt(); ?>
                                             </div>
                                         <?php
                                         }
 
-                                        if( !empty( $slides_single_data['event-date'] ) ) {
-                                            $date_time = event_star_date_time_array( $slides_single_data['event-date'] );
+                                        if (!empty($slides_single_data['event-date'])) {
+                                            $date_time = event_star_date_time_array($slides_single_data['event-date']);
                                             $camp_start_date = $slides_single_data['event-date'];
                                             $camp_end_date = '21/12/2018';
-                                            $now = date( 'd/m/Y - H:i' );
+                                            $now = date('d/m/Y - H:i');
 
-                                            if( !empty( $date_time ) && is_array( $date_time ) ) {
-                                                if ( $now <= $camp_start_date ) {
+                                            if (!empty($date_time) && is_array($date_time)) {
+                                                if ($now <= $camp_start_date) {
                                                     $event_star_days_text = $event_star_customizer_all_values['event-star-days-text'];
                                                     $event_star_hours_text = $event_star_customizer_all_values['event-star-hours-text'];
                                                     $event_star_min_text = $event_star_customizer_all_values['event-star-min-text'];
                                                     $event_star_second_text = $event_star_customizer_all_values['event-star-second-text'];
 
-                                                    include( locate_template( './inc/template-parts/slider/section-countdown.php' ) );
+                                                    include(locate_template('./inc/template-parts/slider/section-countdown.php'));
                                                 } else {
-                                                    $now = date( 'd/m/Y' );
+                                                    $now = date('d/m/Y');
 
-                                                    switch ( $now ) {
+                                                    switch ($now) {
                                                         case '17/12/2018':
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e('The First Day of Cambodia ICT Camp is opening now.', 'ict_camp');
+                                                            _e('The First Day of Cambodia ICT Camp is opening now.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                         case '18/12/2018':
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e( 'The Second Day of Cambodia ICT Camp is ongoing.', 'ict_camp' );
+                                                            _e('The Second Day of Cambodia ICT Camp is ongoing.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                         case '19/12/2018':
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e( 'The Third Day of Cambodia ICT Camp is ongoing.', 'ict_camp' );
+                                                            _e('The Third Day of Cambodia ICT Camp is ongoing.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                         case '20/12/2018':
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e( 'The Fourth Day of Cambodia ICT Camp is ongoing.', 'ict_camp' );
+                                                            _e('The Fourth Day of Cambodia ICT Camp is ongoing.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                         case '21/12/2018':
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e( 'The last day of Cambodia ICT Camp is ongoing.', 'ict_camp' );
+                                                            _e('The last day of Cambodia ICT Camp is ongoing.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                         default:
                                                             echo '<h3 class="after-countdown-text">';
-                                                                _e( 'The Cambodia ICT Camp was ended.', 'ict_camp' );
+                                                            _e('The Cambodia ICT Camp was ended.', 'ict_camp');
                                                             echo '</h3>';
                                                             break;
                                                     }
@@ -227,18 +235,18 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
                                             }
                                         }
 
-                                        if( !empty( $slides_single_data['button-1-text'] ) ) {
+                                        if (!empty($slides_single_data['button-1-text'])) {
                                         ?>
-                                            <a href="<?php echo esc_url( $slides_single_data['button-1-link'] );?>" class="<?php echo esc_attr( $animation4 );?> btn btn-primary btn-reverse outline-outward banner-btn">
-                                                <?php echo esc_html( $slides_single_data['button-1-text'] ); ?>
+                                            <a href="<?php echo esc_url($slides_single_data['button-1-link']); ?>" class="<?php echo esc_attr($animation4); ?> btn btn-primary btn-reverse outline-outward banner-btn">
+                                                <?php echo esc_html($slides_single_data['button-1-text']); ?>
                                             </a>
                                         <?php
                                         }
 
-                                        if( !empty( $slides_single_data['button-2-text'] ) ) {
+                                        if (!empty($slides_single_data['button-2-text'])) {
                                         ?>
-                                            <a href="<?php echo esc_url( $slides_single_data['button-2-link'] );?>" class="<?php echo esc_attr( $animation5 );?> btn btn-primary outline-outward banner-btn">
-                                                <?php echo esc_html( $slides_single_data['button-2-text'] ); ?>
+                                            <a href="<?php echo esc_url($slides_single_data['button-2-link']); ?>" class="<?php echo esc_attr($animation5); ?> btn btn-primary outline-outward banner-btn">
+                                                <?php echo esc_html($slides_single_data['button-2-text']); ?>
                                             </a>
                                         <?php
                                         }
@@ -246,29 +254,31 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
                                     </div>
                                 </div>
                             </div>
-                            <?php
-                            $slider_index ++;
+                        <?php
+                            $slider_index++;
 
-                            if( 3 < $slider_index ) {
+                            if (3 < $slider_index) {
                                 $slider_index = 1;
                             }
                         endwhile;
                         ?>
-                    </div><!--acme slick carousel-->
+                    </div>
+                    <!--acme slick carousel-->
 
                     <?php
                     $event_star_feature_info_display_options = $event_star_customizer_all_values['event-star-feature-info-display-options'];
 
-                    if( 'absolute' == $event_star_feature_info_display_options ){
-                        do_action( 'event_star_action_feature_info' );
+                    if ('absolute' == $event_star_feature_info_display_options) {
+                        do_action('event_star_action_feature_info');
                     }
                     ?>
-                </div><!--.image slider wrapper-->
-                <?php
-            else:
+                </div>
+                <!--.image slider wrapper-->
+<?php
+            else :
                 event_star_default_slider();
             endif;
-        else:
+        else :
             event_star_default_slider();
         endif;
 
@@ -276,4 +286,4 @@ if ( ! function_exists( 'event_star_feature_slider' ) ) :
     }
 endif;
 
-add_action( 'event_star_action_feature_slider', 'event_star_feature_slider', 0 );
+add_action('event_star_action_feature_slider', 'event_star_feature_slider', 0);


### PR DESCRIPTION
Fixed #17 

- Refactor code
- Apply `wp_is_mobile` to detect the screen size for specific photo
- Establish strong dependency on ACF: Advanced Custom Fields plugin